### PR TITLE
Add new redirect rule for /admin/portainer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,10 @@ const nextConfig = {
       {
         source: '/amethyst/:path*',
         destination: 'http://amethyst:8000/:path*'
+      },
+      {
+        source: '/admin/portainer/:path*',
+        destination: 'https://portainer:9443/:path*'
       }
     ]
   }


### PR DESCRIPTION
This update introduces a redirect rule routing /admin/portainer to the Portainer service at https://portainer:9443. It ensures seamless navigation for admin-related requests.