### PR TITLE
Add reverse proxy for amethyst.everthorn.net in nginx

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,10 +33,6 @@ const nextConfig = {
       {
         source: '/amethyst/:path*',
         destination: 'http://amethyst:8000/:path*'
-      },
-      {
-        source: '/admin/portainer/:path*',
-        destination: 'https://portainer:9443/:path*'
       }
     ]
   }

--- a/nginx.conf
+++ b/nginx.conf
@@ -70,3 +70,26 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
+
+# --------- AMETHYST.EVERTHORN.NET
+
+server {
+    server_name amethyst.everthorn.net;
+
+    location / {
+        proxy_pass https://portainer:9443/;
+        proxy_ssl_verify off;  # Portainer manages its own cert
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/everthorn.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/everthorn.net/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}


### PR DESCRIPTION
Configured nginx to proxy requests for amethyst.everthorn.net to a Portainer service. Removed redundant route handling for Portainer in next.config.js to streamline routing through the reverse proxy.